### PR TITLE
used proper method to add custom attribute

### DIFF
--- a/awsif/congito.go
+++ b/awsif/congito.go
@@ -16,5 +16,5 @@ type CognitoClent interface {
 	GetGroup(ctx context.Context, params *cognitoidentityprovider.GetGroupInput, optFns ...func(*cognitoidentityprovider.Options)) (*cognitoidentityprovider.GetGroupOutput, error)
 	AdminRemoveUserFromGroup(ctx context.Context, params *cognitoidentityprovider.AdminRemoveUserFromGroupInput, optFns ...func(*cognitoidentityprovider.Options)) (*cognitoidentityprovider.AdminRemoveUserFromGroupOutput, error)
 	AdminUpdateUserAttributes(ctx context.Context, params *cognitoidentityprovider.AdminUpdateUserAttributesInput, optFns ...func(*cognitoidentityprovider.Options)) (*cognitoidentityprovider.AdminUpdateUserAttributesOutput, error)
-	UpdateUserPool(ctx context.Context, params *cognitoidentityprovider.UpdateUserPoolInput, optFns ...func(*cognitoidentityprovider.Options)) (*cognitoidentityprovider.UpdateUserPoolOutput, error)
+	AddCustomAttributes(ctx context.Context, params *cognitoidentityprovider.AddCustomAttributesInput, optFns ...func(*cognitoidentityprovider.Options)) (*cognitoidentityprovider.AddCustomAttributesOutput, error)
 }


### PR DESCRIPTION
### Description 

I've replaced the `UpdateUserPool` to `AddCustomAttributes` cause it's the one which adds a custom field to an already existing userpool while that one modify other policies but not the schema