### PR TITLE
ENG-662 Wrong US format (separators) is used for thousends and after the coma

### DIFF
--- a/money/money_marshal.go
+++ b/money/money_marshal.go
@@ -132,7 +132,7 @@ func (m *Money) UnmarshalJSON(b []byte) error {
 }
 
 func init() {
-	money.AddCurrency("GER-EUR", "\u20ac", "1 €", ",", ".", 2)
+	money.AddCurrency("EUR", "\u20ac", "1 $", ",", ".", 2)
 
 	money.MarshalJSON = func(m money.Money) ([]byte, error) {
 		mm := jsonMarshalMoneyWithoutVat{

--- a/money/money_marshal.go
+++ b/money/money_marshal.go
@@ -132,7 +132,7 @@ func (m *Money) UnmarshalJSON(b []byte) error {
 }
 
 func init() {
-	money.AddCurrency("DE-EUR", "\u20ac", "1 €", ",", ".", 2)
+	money.AddCurrency("GER-EUR", "\u20ac", "1 €", ",", ".", 2)
 
 	money.MarshalJSON = func(m money.Money) ([]byte, error) {
 		mm := jsonMarshalMoneyWithoutVat{

--- a/money/money_marshal.go
+++ b/money/money_marshal.go
@@ -132,6 +132,8 @@ func (m *Money) UnmarshalJSON(b []byte) error {
 }
 
 func init() {
+	money.AddCurrency("DE-EUR", "\u20ac", "1 €", ",", ".", 2)
+
 	money.MarshalJSON = func(m money.Money) ([]byte, error) {
 		mm := jsonMarshalMoneyWithoutVat{
 			Amount:      m.AsMajorUnits(),

--- a/money/money_test.go
+++ b/money/money_test.go
@@ -37,7 +37,7 @@ func TestNewMoney(t *testing.T) {
 }
 
 func TestDisplayFormatWithoutVAT(t *testing.T) {
-	m := money.NewFromGross(1000_00, "DE-EUR", money.VAT_07_00)
+	m := money.NewFromGross(1000_00, "GER-EUR", money.VAT_07_00)
 
 	expectedFormat := "1.000,00 €"
 

--- a/money/money_test.go
+++ b/money/money_test.go
@@ -37,7 +37,7 @@ func TestNewMoney(t *testing.T) {
 }
 
 func TestDisplayFormatWithoutVAT(t *testing.T) {
-	m := money.NewFromGross(1000_00, "GER-EUR", money.VAT_07_00)
+	m := money.NewFromGross(1000_00, "EUR", money.VAT_07_00)
 
 	expectedFormat := "1.000,00 €"
 

--- a/money/money_test.go
+++ b/money/money_test.go
@@ -36,6 +36,16 @@ func TestNewMoney(t *testing.T) {
 	require.Equal(t, int64(100_00), m.AmountNet(), "19: Net from net")
 }
 
+func TestDisplayFormatWithoutVAT(t *testing.T) {
+	m := money.NewFromGross(1000_00, "DE-EUR", money.VAT_07_00)
+
+	expectedFormat := "1.000,00 €"
+
+	value := m.Display()
+
+	require.Equal(t, expectedFormat, value, fmt.Sprintf("Expected %s, got %s", expectedFormat, m.Display()))
+}
+
 func TestMoneyAdd(t *testing.T) {
 	testCases := []struct {
 		m1          *money.Money


### PR DESCRIPTION
I have changed the EUR currency format to `1.234,99 €`

## Related PR
- https://github.com/Mansio-GmbH/api/pull/308

## Related Ticket
- https://mansio.atlassian.net/jira/software/projects/ENG/boards/13?selectedIssue=ENG-662